### PR TITLE
adding init-db makefile command and modifying migrate-db command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ destroy-all:
 	vagrant box list | cut -f 1 -d ' ' | xargs -L 1 vagrant box remove -f
 	ps -ef |grep VBox | awk '{print $2}' | xargs kill
 
+init-db:
+	vagrant ssh -c "cd /vagrant/repos/snailx_api/api && . /vagrant/venv/bin/activate; FLASK_APP=main.py flask db init"
+
 migrate-db:
-	vagrant ssh -c "cd /vagrant/repos/snailx_api/api && . /vagrant/venv/bin/activate; FLASK_APP=main.py flask db init && FLASK_APP=main.py flask db migrate && FLASK_APP=main.py flask db upgrade"
+	vagrant ssh -c "cd /vagrant/repos/snailx_api/api && . /vagrant/venv/bin/activate; FLASK_APP=main.py flask db migrate && FLASK_APP=main.py flask db upgrade"
 
 test:
 	vagrant ssh -c ". /vagrant/venv/bin/activate; python -m unittest discover -s /vagrant/repos/snailx_api/api -p "*_test.py""


### PR DESCRIPTION
Two line fix to:

- Add init-db makefile command.
- Change migrate-db to only migrate database, without initialising. 
- Ease development for database. 