### PR TITLE
Add Makefile command make test-coverage and make test-xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ venv.bak/
 api/
 .vagrant
 coverage_html/
+test-reports/

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 # vagrant
 api/
 .vagrant
+coverage_html/

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,8 @@ test-coverage:
 	vagrant ssh -c ". /vagrant/venv/bin/activate; coverage run --source /vagrant/repos/snailx_api/api /vagrant/repos/snailx_api/api/test_runner.py test; coverage html -d /vagrant/coverage_html --skip-covered"
 	rm -rf /coverage_html
 	scp -rP 2222 vagrant@127.0.0.1:/vagrant/coverage_html .
+
+test-xml:
+	vagrant ssh -c ". /vagrant/venv/bin/activate; python /vagrant/repos/snailx_api/api/test_runner.py"
+	rm -rf test-reports
+	scp -rP 2222 vagrant@127.0.0.1:/home/vagrant/test-reports .

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install-requirements:
 	pip install flask-sqlalchemy
 	pip install flask-migrate
 	pip install pyjwt
+	pip install coverage
 
 destroy-all:
 	vagrant box list | cut -f 1 -d ' ' | xargs -L 1 vagrant box remove -f
@@ -24,3 +25,8 @@ migrate-db:
 
 test:
 	vagrant ssh -c ". /vagrant/venv/bin/activate; python /vagrant/repos/snailx_api/api/test_runner.py"
+
+test-coverage:
+	vagrant ssh -c ". /vagrant/venv/bin/activate; coverage run --source /vagrant/repos/snailx_api/api /vagrant/repos/snailx_api/api/test_runner.py test; coverage html -d /vagrant/coverage_html --skip-covered"
+	rm -rf /coverage_html
+	scp -rP 2222 vagrant@127.0.0.1:/vagrant/coverage_html .

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ install-requirements:
 	pip install flask-migrate
 	pip install pyjwt
 	pip install coverage
+	pip install unittest-xml-reporting
 
 destroy-all:
 	vagrant box list | cut -f 1 -d ' ' | xargs -L 1 vagrant box remove -f


### PR DESCRIPTION
View test coverage as html output with make test-coverage.
make test-xml is used to generate JUnit style XML reports for our unittests which are uploaded to CircleCI.